### PR TITLE
Partial fix for strange airline behaviour

### DIFF
--- a/autoload/airline/themes/embark.vim
+++ b/autoload/airline/themes/embark.vim
@@ -55,7 +55,7 @@ let g:airline#themes#embark#palette.normal_modified = {
       \ }
 
 let s:I1 = [ s:bg_subtle.gui , s:red.gui , s:bg_subtle.cterm16 , s:red.cterm16]
-let s:I2 = [ s:bg_subtle.gui , s:red.gui , s:bg_subtle.cterm16 , s:red.cterm16]
+let s:I2 = [ s:bg_subtle.gui , s:dark_red.gui , s:bg_subtle.cterm16 , s:dark_red.cterm16]
 let s:I3   = [ s:white.gui, s:bg_subtle.gui, s:white.cterm16, s:bg_subtle.cterm16 ]
 let g:airline#themes#embark#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
 let g:airline#themes#embark#palette.insert_modified = {


### PR DESCRIPTION
I started rewriting the airline theme based on the default dark theme and came across the same strange behaviour when I tried to make airline_a and airline_b have the same background colour.

This small change fixes the majority of the problems I was having but there are still some to iron out.

I think this file is over-engineered and it's confusing airline, I'm going to finish my re-write of the theme and although it's less elegant, I think it'll be more likely to work as expected. I'll make another PR when it's working and stable.