### PR TITLE
add new airline theme

### DIFF
--- a/autoload/airline/themes/embark.vim
+++ b/autoload/airline/themes/embark.vim
@@ -1,115 +1,179 @@
-" Colors
-let s:black           = { "gui": "#212121", "cterm": "0", "cterm16" : "0" }
-let s:medium_gray     = { "gui": "#767676", "cterm": "243", "cterm16" : "243" }
-let s:white           = { "gui": "#F3F3F3", "cterm": "15", "cterm16" : "15" }
-let s:actual_white    = { "gui": "#FFFFFF", "cterm": "231", "cterm16" : "231" }
-let s:light_black     = { "gui": "#424242", "cterm": "8", "cterm16" : "8" }
-let s:lighter_black   = { "gui": "#545454", "cterm": "240", "cterm16" : "240" }
-
-" lighter shadows and darker grays
-let s:subtle_black  = { "gui": "#303030", "cterm": "236", "cterm16" : "236" }
-let s:light_gray    = { "gui": "#B2B2B2", "cterm": "249", "cterm16" : "249" }
-let s:lighter_gray  = { "gui": "#C6C6C6", "cterm": "251", "cterm16" : "251" }
-
-" flat colors:
-let s:space = { "gui": "#1e1c31", "cterm": "233", "cterm16": "NONE"}
-let s:deep_space= { "gui": "#100E23", "cterm": "232", "cterm16": "8"}
-let s:eclipse = { "gui": "#3E3859", "cterm": "236", "cterm16": "0"}
-
-let s:red = { "gui": "#F48FB1", "cterm": "204", "cterm16": "1"}
-let s:dark_red = { "gui": "#ff5458", "cterm": "203", "cterm16": "9"}
-
-let s:green = { "gui": "#A1EFD3", "cterm": "120", "cterm16": "2"}
-let s:dark_green = { "gui": "#62d196", "cterm": "119", "cterm16": "10"}
-
-let s:yellow = { "gui": "#ffe9aa", "cterm": "228", "cterm16": "3"}
-let s:dark_yellow = { "gui": "#ffb378", "cterm": "215", "cterm16": "11"}
-
-let s:blue = { "gui": "#91ddff", "cterm": "159", "cterm16": "4"}
-let s:dark_blue = { "gui": "#65b2ff", "cterm": "75", "cterm16": "12"}
-
-let s:purple = { "gui": "#c991e1", "cterm": "141", "cterm16": "5"}
-let s:dark_purple = { "gui": "#906cff", "cterm": "135", "cterm16": "13"}
-
-let s:cyan = { "gui": "#aaffe4", "cterm": "122", "cterm16": "6"}
-let s:dark_cyan = { "gui": "#63f2f1", "cterm": "121", "cterm16": "14"}
-
-let s:stardust = { "gui": "#cbe3e7", "cterm": "253", "cterm16": "7"}
-let s:cosmos = { "gui": "#a6b3cc", "cterm": "252", "cterm16": "15"}
-
-let s:bg              = s:space
-let s:bg_subtle       = s:deep_space
-let s:bg_dark         = s:eclipse
-let s:norm            = s:stardust
-let s:norm_subtle     = s:cosmos
-let s:visual          = s:bg_subtle
+scriptencoding utf-8
 let g:airline#themes#embark#palette = {}
 
-let s:N1   = [ s:bg_subtle.gui, s:cyan.gui, s:bg_subtle.cterm16, s:cyan.cterm16 ]
-let s:N2   = [ s:bg_subtle.gui, s:dark_cyan.gui, s:bg_subtle.cterm16, s:dark_cyan.cterm16 ]
-let s:N3   = [ s:white.gui, s:bg_subtle.gui, s:white.cterm16, s:bg_subtle.cterm16 ]
-let g:airline#themes#embark#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
+" Airline sections are as follows:
+"_______________________________________________________________
+"| a | b |     c               x     | y | z | warning | error |
+"¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯
+
+" airline_a (left most section)
+" airline_b (section just to the right of airline_a)
+" airline_c (section just to the right of airline_b)
+" airline_x (first section of the right most sections)
+" airline_y (section just to the right of airline_x)
+" airline_z (right most section with no warnings or errors)
+" airline_warning (warning section)
+" airline_error (error section)
+
+" values in the arrays are as follows:
+" [guifg, guibg, ctermfg, ctermbg, opts]
+
+" 'opts' can be any of the following: 
+" bold, underline, undercurl, reverse, inverse, italic, standout, strikethrough, NONE
+
+"----------------- NORMAL MODE ----------------------------
+
+let g:airline#themes#embark#palette.normal = {
+      \  'airline_a':       [ '#100e23' , '#aaffe4' , 232  , 122 ],
+      \  'airline_b':       [ '#100e23' , '#63f2f1' , 232  , 121 ],
+      \  'airline_c':       [ '#ffffff' , '#100e23' , 255  , 232 ],
+      \  'airline_x':       [ '#63f2f1' , '#100e23' , 255  , 232 ],
+      \  'airline_y':       [ '#100e23' , '#63f2f1' , 232  , 121 ],
+      \  'airline_z':       [ '#100e23' , '#aaffe4' , 232  , 122 ],
+      \  'airline_warning': [ '#100e23' , '#F48FB1' , 232  , 204 ],
+      \  'airline_error':   [ '#100e23' , '#ff5458' , 232  , 203 ],
+      \ }
 
 let g:airline#themes#embark#palette.normal_modified = {
-      \ 'airline_c': [ s:N3[0] , s:N3[1] , s:N3[2] , s:N3[3], ''     ] ,
+      \  'airline_c':       [ '#F48FB1' , '#100e23' , 204  , 232 , '' ],
+      \  'airline_warning': [ '#100e23' , '#F48FB1' , 232  , 204 ],
+      \  'airline_error':   [ '#100e23' , '#ff5458' , 232  , 203 ],
       \ }
 
-let s:I1 = [ s:bg_subtle.gui , s:red.gui , s:bg_subtle.cterm16 , s:red.cterm16]
-let s:I2 = [ s:bg_subtle.gui , s:dark_red.gui , s:bg_subtle.cterm16 , s:dark_red.cterm16]
-let s:I3   = [ s:white.gui, s:bg_subtle.gui, s:white.cterm16, s:bg_subtle.cterm16 ]
-let g:airline#themes#embark#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
+"----------------- INSERT MODE ----------------------------
+
+let g:airline#themes#embark#palette.insert = {
+      \  'airline_a':       [ '#100e23' , '#F48FB1' , 232  , 204 ],
+      \  'airline_b':       [ '#100e23' , '#ff5458' , 232  , 203 ],
+      \  'airline_c':       [ '#ffffff' , '#100e23' , 255  , 232 ],
+      \  'airline_x':       [ '#ff5458' , '#100e23' , 255  , 232 ],
+      \  'airline_y':       [ '#100e23' , '#ff5458' , 232  , 203 ],
+      \  'airline_z':       [ '#100e23' , '#F48FB1' , 232  , 204 ],
+      \  'airline_warning': [ '#ffffff' , '#ff5458' , 255  , 203 ],
+      \  'airline_error':   [ '#ffffff' , '#af0000' , 255  , 124 ],
+      \ }
+
 let g:airline#themes#embark#palette.insert_modified = {
-      \ 'airline_c': [ s:white.gui , s:bg_subtle.gui , s:white.cterm16, s:bg_subtle.cterm16      , ''     ] ,
+      \  'airline_c':       [ '#F48FB1' , '#100e23' , 204  , 232 , '' ],
+      \  'airline_warning': [ '#100e23' , '#ff5458' , 232  , 203 ],
+      \  'airline_error':   [ '#ffffff' , '#af0000' , 232  , 124 ],
       \ }
+
 let g:airline#themes#embark#palette.insert_paste = {
-      \ 'airline_a': [ s:I1[0]   , s:yellow.gui , s:I1[2] , s:yellow.cterm16     , ''     ] ,
+      \ 'airline_a':        [ '#100e23' , '#ffe9aa' , 232  , 228 , '' ]
       \ }
 
+"----------------- VISUAL MODE ----------------------------
 
-let g:airline#themes#embark#palette.replace = copy(g:airline#themes#embark#palette.insert)
-let g:airline#themes#embark#palette.replace.airline_a = [ s:I2[0]   , s:yellow.gui , s:I2[2] , s:yellow.cterm16     , ''     ]
-let g:airline#themes#embark#palette.replace_modified = g:airline#themes#embark#palette.insert_modified
+let g:airline#themes#embark#palette.visual= {
+      \  'airline_a':       [ '#100e23' , '#ffe9aa' , 232  , 228 ],
+      \  'airline_b':       [ '#100e23' , '#ffb378' , 232  , 215 ],
+      \  'airline_c':       [ '#ffffff' , '#100e23' , 255  , 232 ],
+      \  'airline_x':       [ '#ffb378' , '#100e23' , 255  , 232 ],
+      \  'airline_y':       [ '#100e23' , '#ffb378' , 232  , 215 ],
+      \  'airline_z':       [ '#100e23' , '#ffe9aa' , 232  , 228 ],
+      \  'airline_warning': [ '#100e23' , '#F48FB1' , 232  , 204 ],
+      \  'airline_error':   [ '#100e23' , '#ff5458' , 232  , 203 ],
+      \ }
 
-
-let s:V1 = [ s:bg_subtle.gui , s:yellow.gui , s:bg_subtle.cterm16 , s:yellow.cterm16]
-let s:V2 = [ s:bg_subtle.gui , s:dark_yellow.gui , s:bg_subtle.cterm16 , s:dark_yellow.cterm16]
-let s:V3   = [ s:white.gui, s:bg_subtle.gui, s:white.cterm16, s:bg_subtle.cterm16 ]
-let g:airline#themes#embark#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
 let g:airline#themes#embark#palette.visual_modified = {
-      \ 'airline_c': [ s:V3[0] , s:V3[1] , s:V3[2] , s:V3[3], ''     ] ,
+      \  'airline_c':       [ '#F48FB1' , '#100e23' , 204  , 232 , '' ],
+      \  'airline_warning': [ '#100e23' , '#F48FB1' , 232  , 204 ],
+      \  'airline_error':   [ '#100e23' , '#ff5458' , 232  , 203 ],
       \ }
 
-let s:IA1 = [ s:bg_subtle.gui , s:purple.gui , s:bg_subtle.cterm16 , s:purple.cterm16]
-let s:IA2 = [ s:bg_subtle.gui , s:dark_purple.gui , s:bg_subtle.cterm16 , s:dark_purple.cterm16]
-let s:IA3   = [ s:white.gui, s:bg_subtle.gui, s:white.cterm16, s:bg_subtle.cterm16 ]
-let g:airline#themes#embark#palette.inactive = airline#themes#generate_color_map(s:IA1, s:IA2, s:IA3)
-let g:airline#themes#embark#palette.inactive_modified = {
-      \ 'airline_c': [ s:IA3[0] , s:IA3[1] , s:IA3[2] , s:IA3[3], ''     ] ,
+"----------------- COMMANDLINE MODE -----------------------
+
+let g:airline#themes#embark#palette.commandline = {
+      \  'airline_a':       [ '#100e23' , '#c991e1' , 232  , 141 ],
+      \  'airline_b':       [ '#100e23' , '#906cff' , 232  , 135 ],
+      \  'airline_c':       [ '#ffffff' , '#100e23' , 255  , 232 ],
+      \  'airline_x':       [ '#906cff' , '#100e23' , 255  , 232 ],
+      \  'airline_y':       [ '#100e23' , '#906cff' , 232  , 135 ],
+      \  'airline_z':       [ '#100e23' , '#c991e1' , 232  , 141 ],
+      \  'airline_warning': [ '#100e23' , '#F48FB1' , 232  , 204 ],
+      \  'airline_error':   [ '#100e23' , '#ff5458' , 232  , 203 ],
       \ }
 
 
-let s:WI = [ s:bg_subtle.gui, s:red.gui, s:bg_subtle.cterm16, s:red.cterm16 ]
-let g:airline#themes#embark#palette.normal.airline_warning = [
-     \ s:WI[0], s:WI[1], s:WI[2], s:WI[3]
-     \ ]
+let g:airline#themes#embark#palette.commandline_modified = {
+      \  'airline_c':       [ '#F48FB1' , '#100e23' , 204  , 232 , '' ],
+      \  'airline_warning': [ '#100e23' , '#F48FB1' , 232  , 204 ],
+      \  'airline_error':   [ '#100e23' , '#ff5458' , 232  , 203 ],
+      \ }
 
-let g:airline#themes#embark#palette.normal_modified.airline_warning =
-    \ g:airline#themes#embark#palette.normal.airline_warning
+"----------------- TERMINAL MODE --------------------------
 
-let g:airline#themes#embark#palette.insert.airline_warning =
-    \ g:airline#themes#embark#palette.normal.airline_warning
+let g:airline#themes#embark#palette.terminal = {
+      \  'airline_a':       [ '#100e23' , '#91ddff' , 232  , 159 ],
+      \  'airline_b':       [ '#100e23' , '#65b2ff' , 232  ,  75 ],
+      \  'airline_c':       [ '#ffffff' , '#100e23' , 255  , 232 ],
+      \  'airline_x':       [ '#65b2ff' , '#100e23' , 255  , 232 ],
+      \  'airline_y':       [ '#100e23' , '#65b2ff' , 232  ,  75 ],
+      \  'airline_z':       [ '#100e23' , '#91ddff' , 232  , 159 ],
+      \  'airline_warning': [ '#100e23' , '#F48FB1' , 232  , 204 ],
+      \  'airline_error':   [ '#100e23' , '#ff5458' , 232  , 203 ],
+      \ }
 
-let g:airline#themes#embark#palette.insert_modified.airline_warning =
-    \ g:airline#themes#embark#palette.normal.airline_warning
+"----------------- REPLACE MODE ---------------------------
 
-let g:airline#themes#embark#palette.visual.airline_warning =
-    \ g:airline#themes#embark#palette.normal.airline_warning
+let g:airline#themes#embark#palette.replace = {
+      \  'airline_a':       [ '#100e23' , '#A1EFD3' , 232  , 204 ],
+      \  'airline_b':       [ '#100e23' , '#62d196' , 232  , 203 ],
+      \  'airline_c':       [ '#ffffff' , '#100e23' , 255  , 232 ],
+      \  'airline_x':       [ '#62d196' , '#100e23' , 255  , 232 ],
+      \  'airline_y':       [ '#100e23' , '#62d196' , 232  , 203 ],
+      \  'airline_z':       [ '#100e23' , '#A1EFD3' , 232  , 204 ],
+      \  'airline_warning': [ '#ffffff' , '#F48FB1' , 255  , 203 ],
+      \  'airline_error':   [ '#ffffff' , '#ff5458' , 255  , 124 ],
+      \ }
 
-let g:airline#themes#embark#palette.visual_modified.airline_warning =
-    \ g:airline#themes#embark#palette.normal.airline_warning
+let g:airline#themes#embark#palette.replace_modified = {
+      \  'airline_c':       [ '#F48FB1' , '#100e23' , 204  , 232 , '' ],
+      \  'airline_warning': [ '#100e23' , '#F48FB1' , 232  , 204],
+      \  'airline_error':   [ '#ffffff' , '#ff5458' , 232  , 203],
+      \ }
 
-let g:airline#themes#embark#palette.replace.airline_warning =
-    \ g:airline#themes#embark#palette.normal.airline_warning
+"------------------ INACTIVE (MODE) -----------------------
 
-let g:airline#themes#embark#palette.replace_modified.airline_warning =
-    \ g:airline#themes#embark#palette.normal.airline_warning
+let g:airline#themes#embark#palette.inactive= {
+      \  'airline_a':       [ '#3E3859' , '#100e23' , 236  , 232 ],
+      \  'airline_b':       [ '#100e23' , '#3E3859' , 232  , 236 ],
+      \  'airline_c':       [ '#3E3859' , '#100e23' , 236  , 232 ],
+      \  'airline_x':       [ '#3E3859' , '#100e23' , 236  , 232 ],
+      \  'airline_y':       [ '#100e23' , '#3E3859' , 232  , 236 ],
+      \  'airline_z':       [ '#3E3859' , '#100e23' , 236  , 232 ],
+      \  'airline_warning': [ '#100e23' , '#F48FB1' , 232  , 204 ],
+      \  'airline_error':   [ '#100e23' , '#ff5458' , 232  , 203 ],
+      \ }
+
+let g:airline#themes#embark#palette.inactive_modified= {
+      \  'airline_c':       [ '#3E3859' , ''        , 236  , ''  , '' ],
+      \  'airline_warning': [ '#100e23' , '#F48FB1' , 232  , 204 ],
+      \  'airline_error':   [ '#100e23' , '#ff5458' , 232  , 203 ],
+      \ }
+
+"------------------ TABLINE -------------------------------
+
+let g:airline#themes#embark#palette.tabline = { 
+      \ 'airline_tablabel':           [ '#100e23' , '#63f2f1' , 232 , 121 , 'bold'],
+      \ 'airline_tab':                [ '#ffffff' , '#100e23' , 255 , 232 ,     ''],
+      \ 'airline_tabsel':             [ '#100e23' , '#aaffe4' , 232 , 122 ,     ''],
+      \ 'airline_tabtype':            [ '#100e23' , '#906cff' , 232 , 135 ,     ''],
+      \ 'airline_tabfill':            [ '#ffffff' , '#100e23' , 255 , 232 ,     ''],
+      \ 'airline_tabmod':             [ '#100e23' , '#F48FB1' , 232 , 204 ,     ''],
+      \ 'airline_tabmod_unsel':       [ '#F48FB1' , '#100e23' , 204 , 232 ,     ''],
+      \ 'airline_tabhid':             [ '#ffffff' , '#100e23' , 255 , 232 ,     ''],
+      \ 'airline_tablabel_right':     [ '#100e23' , '#63f2f1' , 232 , 121 , 'bold'],
+      \ 'airline_tab_right':          [ '#ffffff' , '#3E3859' , 255 , 232 ,     ''],
+      \ 'airline_tabsel_right':       [ '#100e23' , '#aaffe4' , 232 , 122 ,     ''],
+      \ 'airline_tabmod_right':       [ '#100e23' , '#F48FB1' , 232 , 204 ,     ''],
+      \ 'airline_tabmod_unsel_right': [ '#F48FB1' , '#100e23' , 204 , 232 ,     ''],
+      \ 'airline_tabhid_right':       [ '#ffffff' , '#100e23' , 255 , 232 ,     ''],
+      \ }
+
+"------------------ ACCENT ----------------------------------
+
+let g:airline#themes#embark#palette.accents = {
+      \ 'red': [ '#ff0000' , '' , 160 , ''  ]
+      \ }


### PR DESCRIPTION
Ok I think I've done what you suggested and made a airline-rewrite branch to push to. Wasn't sure where to make the PR as I saw you have a "airline-sync-fix" branch but GitHub said it was unable to merge there so I went for master. Is that right?

As for the rewrite, I didn't actually use the "dark" template theme because it wasn't actually a template, it was more of a demo of the features and helper functions you can use in airline themes.

Some other themes I found had what I think is a bit of an over-engineered and convoluted way of defining the colours. They defined them in colour arrays, then had to make new "section arrays" where each element is calling one element from a colour array and then another level of mode arrays calling those sections (array-ception). That combined with using helper functions and whatever else it ends up being pretty hard to decipher, not very flexible and even though designed to be less error prone, was likely moreso.

IMO it wasn't as pretty but far easier and more effective to just hard-code the values (with the help of [colorizer](https://github.com/norcalli/nvim-colorizer.lua) to see what I was doing) and not have to rely on any helper functions etc.

Not had any issues with sync using this rewrite for a couple of days but did notice it was a bit buggy with one of the other themes that relied on the helper functions so I suspect there's a problem there somewhere.

What do you think?

![ALL3](https://user-images.githubusercontent.com/43091756/93791561-500cd400-fc2c-11ea-80d0-20abed24b54f.png)
