### PR TITLE
Clean up theme variables

### DIFF
--- a/autoload/lightline/colorscheme/embark.vim
+++ b/autoload/lightline/colorscheme/embark.vim
@@ -1,10 +1,7 @@
 " Colors
-let s:medium_gray     = { "gui": "#767676", "cterm": "243", "cterm16" : "243" }
-let s:white           = { "gui": "#F3F3F3", "cterm": "15", "cterm16" : "15" }
-
 " challenger deep colors:
-let s:space = { "gui": "#1e1c31", "cterm": "233", "cterm16": "NONE"}
 let s:deep_space= { "gui": "#100E23", "cterm": "232", "cterm16": "8"}
+let s:space = { "gui": "#1e1c31", "cterm": "233", "cterm16": "NONE"}
 let s:eclipse = { "gui": "#3E3859", "cterm": "236", "cterm16": "0"}
 
 let s:red = { "gui": "#F48FB1", "cterm": "204", "cterm16": "1"}
@@ -29,16 +26,14 @@ let s:clouds = { "gui": "#cbe3e7", "cterm": "253", "cterm16": "7"}
 let s:dark_clouds = { "gui": "#a6b3cc", "cterm": "252", "cterm16": "15"}
 
 let s:bg              = s:space
-let s:bg_subtle       = s:deep_space
-let s:bg_dark         = s:eclipse
+let s:bg_dark       = s:deep_space
+let s:bg_bright         = s:eclipse
 let s:norm            = s:clouds
 let s:norm_subtle     = s:dark_clouds
-let s:visual          = s:bg_dark
+let s:visual          = s:bg_bright
 
 " lightline challenger deep colors:
 let s:lfc = {
-      \'medium_gray': [ s:medium_gray.gui, s:medium_gray.cterm16],
-      \'white': [ s:white.gui, s:white.cterm16],
       \'space': [s:space.gui, s:space.cterm16],
       \'deep_space': [s:deep_space.gui, s:deep_space.cterm16],
       \'eclipse' : [s:eclipse.gui, s:eclipse.cterm16],
@@ -57,8 +52,8 @@ let s:lfc = {
       \'clouds' : [s:clouds.gui, s:clouds.cterm16],
       \'dark_clouds' : [s:dark_clouds.gui, s:dark_clouds.cterm16],
       \'bg': [s:bg.gui, s:bg.cterm16],
-      \'bg_subtle': [s:bg_subtle.gui, s:bg_subtle.cterm16],
       \'bg_dark': [s:bg_dark.gui, s:bg_dark.cterm16],
+      \'bg_bright': [s:bg_bright.gui, s:bg_bright.cterm16],
       \'norm': [s:norm.gui, s:norm.cterm16],
       \'norm_subtle': [s:norm_subtle.gui, s:norm_subtle.cterm16],
       \}
@@ -66,34 +61,34 @@ let s:lfc = {
 let s:p = { 'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {} }
 
 " Tabline
-let s:p.tabline.left    = [ [ s:lfc.white, s:lfc.bg_subtle ], [s:lfc.white, s:lfc.eclipse] ]
-let s:p.tabline.tabsel  = [ [ s:lfc.bg_subtle, s:lfc.dark_cyan ] ]
-let s:p.tabline.middle  = [ [ s:lfc.white, s:lfc.bg_subtle ] ]
-let s:p.tabline.right   = [ [ s:lfc.bg_subtle, s:lfc.dark_cyan ] ]
+let s:p.tabline.left    = [ [ s:lfc.clouds, s:lfc.bg_dark ], [s:lfc.clouds, s:lfc.eclipse] ]
+let s:p.tabline.tabsel  = [ [ s:lfc.bg_dark, s:lfc.dark_cyan ] ]
+let s:p.tabline.middle  = [ [ s:lfc.clouds, s:lfc.bg_dark ] ]
+let s:p.tabline.right   = [ [ s:lfc.bg_dark, s:lfc.dark_cyan ] ]
 
 " Normal mode
-let s:p.normal.left     = [ [ s:lfc.bg_subtle, s:lfc.cyan ],  [ s:lfc.dark_clouds, s:lfc.eclipse ] ]
-let s:p.normal.middle   = [ [ s:lfc.white, s:lfc.bg_subtle ] ]
-let s:p.normal.right    = [ [ s:lfc.bg_subtle, s:lfc.cyan ],  [ s:lfc.dark_clouds, s:lfc.eclipse ] ]
-let s:p.normal.error    = [ [ s:lfc.red, s:lfc.bg_subtle ] ]
-let s:p.normal.warning  = [ [ s:lfc.yellow, s:lfc.bg_subtle ] ]
+let s:p.normal.left     = [ [ s:lfc.bg_dark, s:lfc.cyan ],  [ s:lfc.dark_clouds, s:lfc.eclipse ] ]
+let s:p.normal.middle   = [ [ s:lfc.clouds, s:lfc.bg_dark ] ]
+let s:p.normal.right    = [ [ s:lfc.bg_dark, s:lfc.cyan ],  [ s:lfc.dark_clouds, s:lfc.eclipse ] ]
+let s:p.normal.error    = [ [ s:lfc.red, s:lfc.bg_dark ] ]
+let s:p.normal.warning  = [ [ s:lfc.yellow, s:lfc.bg_dark ] ]
 
 " Visual mode
-let s:p.visual.left     = [ [ s:lfc.bg_subtle, s:lfc.yellow ],  [ s:lfc.bg_subtle, s:lfc.dark_yellow ] ]
-let s:p.visual.right    = [ [ s:lfc.bg_subtle, s:lfc.yellow ],  [ s:lfc.bg_subtle, s:lfc.dark_yellow ] ]
+let s:p.visual.left     = [ [ s:lfc.bg_dark, s:lfc.yellow ],  [ s:lfc.bg_dark, s:lfc.dark_yellow ] ]
+let s:p.visual.right    = [ [ s:lfc.bg_dark, s:lfc.yellow ],  [ s:lfc.bg_dark, s:lfc.dark_yellow ] ]
 
 " Replace mode
-let s:p.replace.left    = [ [ s:lfc.bg_subtle, s:lfc.green ],  [ s:lfc.bg_subtle, s:lfc.dark_green ] ]
-let s:p.replace.right   = [ [ s:lfc.bg_subtle, s:lfc.green ],  [ s:lfc.bg_subtle, s:lfc.dark_green ] ]
+let s:p.replace.left    = [ [ s:lfc.bg_dark, s:lfc.green ],  [ s:lfc.bg_dark, s:lfc.dark_green ] ]
+let s:p.replace.right   = [ [ s:lfc.bg_dark, s:lfc.green ],  [ s:lfc.bg_dark, s:lfc.dark_green ] ]
 
 " Insert mode
-let s:p.insert.left     = [ [ s:lfc.bg_subtle, s:lfc.red ],  [ s:lfc.bg_subtle, s:lfc.dark_red ] ]
-let s:p.insert.right    = [ [ s:lfc.bg_subtle, s:lfc.red ],  [ s:lfc.bg_subtle, s:lfc.dark_red ] ]
+let s:p.insert.left     = [ [ s:lfc.bg_dark, s:lfc.red ],  [ s:lfc.bg_dark, s:lfc.dark_red ] ]
+let s:p.insert.right    = [ [ s:lfc.bg_dark, s:lfc.red ],  [ s:lfc.bg_dark, s:lfc.dark_red ] ]
 
 " Inactive split
-let s:p.inactive.left   = [ [ s:lfc.eclipse, s:lfc.bg_subtle ], [ s:lfc.eclipse, s:lfc.bg_subtle ] ]
-let s:p.inactive.middle = [ [ s:lfc.eclipse, s:lfc.bg_subtle ] ]
-let s:p.inactive.right  = [ [ s:lfc.eclipse, s:lfc.bg_subtle ], [ s:lfc.eclipse, s:lfc.bg_subtle ] ]
+let s:p.inactive.left   = [ [ s:lfc.eclipse, s:lfc.bg_dark ], [ s:lfc.eclipse, s:lfc.bg_dark ] ]
+let s:p.inactive.middle = [ [ s:lfc.eclipse, s:lfc.bg_dark ] ]
+let s:p.inactive.right  = [ [ s:lfc.eclipse, s:lfc.bg_dark ], [ s:lfc.eclipse, s:lfc.bg_dark ] ]
 
 let g:lightline#colorscheme#embark#palette = lightline#colorscheme#flatten(s:p)
 

--- a/colors/embark.vim
+++ b/colors/embark.vim
@@ -25,8 +25,8 @@ endif
 " == COLOR PALETTE == 
 "
 " TODO: Cterm values here are OG from Challenger Deep
-let s:space = { "gui": "#1e1c31", "cterm": "233", "cterm16": "NONE"}
 let s:deep_space= { "gui": "#100E23", "cterm": "232", "cterm16": "0"}
+let s:space = { "gui": "#1e1c31", "cterm": "233", "cterm16": "NONE"}
 let s:eclipse = { "gui": "#585273", "cterm": "236", "cterm16": "8"}
 
 let s:stardust = { "gui": "#cbe3e7", "cterm": "253", "cterm16": "7"}
@@ -53,11 +53,11 @@ let s:dark_cyan = { "gui": "#63f2f1", "cterm": "121", "cterm16": "14"}
 let s:medium_gray     = { "gui": "#767676", "cterm": "243", "cterm16" : "243" }
 
 let s:bg              = s:space
-let s:bg_subtle       = s:deep_space
-let s:bg_dark         = s:eclipse
+let s:bg_dark       = s:deep_space
+let s:bg_bright         = s:eclipse
 let s:norm            = s:stardust
 let s:norm_subtle     = s:cosmos
-let s:visual          = s:bg_dark
+let s:visual          = s:bg_bright
 
 let s:head_a         = s:dark_blue
 let s:head_b         = s:blue
@@ -92,7 +92,7 @@ endfunction
 "
 " (see `:h w18`)
 call s:h("Normal",        {"bg": s:bg, "fg": s:norm})
-call s:h("Cursor",        {"bg": s:blue, "fg": s:bg_dark})
+call s:h("Cursor",        {"bg": s:blue, "fg": s:bg_bright})
 call s:h("Comment",       {"fg": s:medium_gray, "gui": "italic", "cterm": "italic"})
 
 call s:h("Constant",      {"fg": s:yellow})
@@ -136,7 +136,7 @@ hi! link Debug            Special
 
 call s:h("Underlined",    {"fg": s:norm, "gui": "underline", "cterm": "underline"})
 call s:h("Ignore",        {"fg": s:bg})
-call s:h("Error",         {"fg": s:dark_red, "bg": s:bg_subtle , "gui": "bold", "cterm": "bold"})
+call s:h("Error",         {"fg": s:dark_red, "bg": s:bg_dark , "gui": "bold", "cterm": "bold"})
 call s:h("Todo",          {"fg": s:dark_yellow, "bg": s:bg, "gui": "bold", "cterm": "bold"})
 
 " == UI CHROME ==
@@ -146,7 +146,7 @@ call s:h("SpecialKey",    {"fg": s:blue})
 call s:h("Boolean",    {"fg": s:dark_yellow})
 call s:h("Number",    {"fg": s:dark_yellow})
 call s:h("Float",    {"fg": s:dark_yellow})
-call s:h("NonText",       {"fg": s:bg_dark})
+call s:h("NonText",       {"fg": s:bg_bright})
 call s:h("Directory",     {"fg": s:purple})
 call s:h("ErrorMsg",      {"fg": s:dark_red})
 call s:h("IncSearch",     {"bg": s:yellow, "fg": s:space})
@@ -154,19 +154,19 @@ call s:h("Search",        {"bg": s:dark_yellow, "fg": s:space})
 call s:h("MoreMsg",       {"fg": s:medium_gray, "gui": "bold", "cterm": "bold"})
 hi! link ModeMsg MoreMsg
 
-call s:h("LineNr",        {"fg": s:eclipse, "bg": s:bg_subtle})
+call s:h("LineNr",        {"fg": s:eclipse, "bg": s:bg_dark})
 hi LineNr guibg=NONE ctermbg=NONE
 
-call s:h("CursorLineNr",  {"bg": s:bg_subtle, "fg": s:blue, "gui": "bold"})
+call s:h("CursorLineNr",  {"bg": s:bg_dark, "fg": s:blue, "gui": "bold"})
 call s:h("Question",      {"fg": s:red})
-call s:h("StatusLine",    {"bg": s:bg_dark})
+call s:h("StatusLine",    {"bg": s:bg_bright})
 call s:h("Conceal",       {"fg": s:norm})
-call s:h("StatusLineNC",  {"bg": s:bg_dark, "fg": s:medium_gray})
-call s:h("VertSplit",     {"fg": s:bg_subtle})
+call s:h("StatusLineNC",  {"bg": s:bg_bright, "fg": s:medium_gray})
+call s:h("VertSplit",     {"fg": s:bg_dark})
 call s:h("Title",         {"fg": s:dark_blue})
 call s:h("Visual",        {"bg": s:visual})
 call s:h("WarningMsg",    {"fg": s:yellow})
-call s:h("WildMenu",      {"fg": s:bg_subtle, "bg": s:cyan})
+call s:h("WildMenu",      {"fg": s:bg_dark, "bg": s:cyan})
 call s:h("Folded",        {"fg": s:dark_purple})
 call s:h("FoldColumn",    {"fg": s:yellow})
 call s:h("DiffAdd",       {"fg": s:space, "bg": s:dark_green})
@@ -188,14 +188,14 @@ else
 endif
 call s:h("Pmenu",         {"fg": s:norm, "bg": s:deep_space})
 call s:h("PmenuSel",      {"fg": s:purple, "bg": s:space})
-call s:h("PmenuSbar",     {"fg": s:norm, "bg": s:bg_subtle})
-call s:h("PmenuThumb",    {"fg": s:norm, "bg": s:bg_subtle})
-call s:h("TabLine",       {"fg": s:norm, "bg": s:bg_dark})
-call s:h("TabLineSel",    {"fg": s:norm, "bg": s:bg_subtle, "gui": "bold", "cterm": "bold"})
-call s:h("TabLineFill",   {"fg": s:norm, "bg": s:bg_dark})
-call s:h("CursorColumn",  {"bg": s:bg_subtle})
-call s:h("CursorLine",    {"bg": s:bg_subtle})
-call s:h("ColorColumn",   {"bg": s:bg_subtle})
+call s:h("PmenuSbar",     {"fg": s:norm, "bg": s:bg_dark})
+call s:h("PmenuThumb",    {"fg": s:norm, "bg": s:bg_dark})
+call s:h("TabLine",       {"fg": s:norm, "bg": s:bg_bright})
+call s:h("TabLineSel",    {"fg": s:norm, "bg": s:bg_dark, "gui": "bold", "cterm": "bold"})
+call s:h("TabLineFill",   {"fg": s:norm, "bg": s:bg_bright})
+call s:h("CursorColumn",  {"bg": s:bg_dark})
+call s:h("CursorLine",    {"bg": s:bg_dark})
+call s:h("ColorColumn",   {"bg": s:bg_dark})
 
 " == PLUGIN SUPPORT GROUPS ==
 "
@@ -294,7 +294,7 @@ hi! link xmlTag                     htmlTag
 hi! link xmlEndTag                  xmlTag
 hi! link xmlTagName                 htmlTagName
 
-call s:h("MatchParen",    {"bg": s:bg_subtle, "fg": s:purple, "gui": "bold", "cterm": "bold"})
+call s:h("MatchParen",    {"bg": s:bg_dark, "fg": s:purple, "gui": "bold", "cterm": "bold"})
 call s:h("qfLineNr",      {"fg": s:medium_gray})
 
 " Signify, git-gutter
@@ -316,17 +316,17 @@ call s:h("NERDTreeDir", {"fg": s:blue})
 call s:h("NERDTreeFlags", {"fg": s:green})
 
 " nvim LSP
-call s:h ("LspDiagnosticsError", {"fg": s:red, "bg": s:bg_subtle})
-call s:h ("LspDiagnosticsWarning", {"fg": s:yellow, "bg": s:bg_subtle})
-call s:h ("LspDiagnosticsInformation", {"fg": s:blue, "bg": s:bg_subtle})
-call s:h ("LspDiagnosticsHint", {"fg": s:purple, "bg": s:bg_subtle})
+call s:h ("LspDiagnosticsError", {"fg": s:red, "bg": s:bg_dark})
+call s:h ("LspDiagnosticsWarning", {"fg": s:yellow, "bg": s:bg_dark})
+call s:h ("LspDiagnosticsInformation", {"fg": s:blue, "bg": s:bg_dark})
+call s:h ("LspDiagnosticsHint", {"fg": s:purple, "bg": s:bg_dark})
 call s:h ("LspDiagnosticsErrorSign", {"bg": s:bg})
 call s:h ("LspDiagnosticsWarningSign", {"bg": s:bg})
 call s:h ("LspDiagnosticsInformationSign", {"bg": s:bg})
 call s:h ("LspDiagnosticsHintSign", {"bg": s:bg})
 
 " nvim terminal colors
-let g:terminal_color_0 = s:bg_dark.gui
+let g:terminal_color_0 = s:bg_bright.gui
 let g:terminal_color_1 = s:red.gui
 let g:terminal_color_2 = s:green.gui
 let g:terminal_color_3 = s:yellow.gui
@@ -334,7 +334,7 @@ let g:terminal_color_4 = s:blue.gui
 let g:terminal_color_5 = s:purple.gui
 let g:terminal_color_6 = s:cyan.gui
 let g:terminal_color_7 = s:space.gui
-let g:terminal_color_8 = s:bg_subtle.gui
+let g:terminal_color_8 = s:bg_dark.gui
 let g:terminal_color_9 = s:dark_red.gui
 let g:terminal_color_10 = s:dark_green.gui
 let g:terminal_color_11 = s:dark_yellow.gui


### PR DESCRIPTION
* Reorganize background colors to be light to dark
* Rename bg variables
* Remove white color from lightline palette
* Remove unused gray color from lightline palette

The original variables come from Challenger deep where they used terms
like `bg_sublte` and `bg_dark`. These were confusing because `bg_subtle`
was darker than `bg_dark`. Renamed them so that variable aligns with how
dark they are.