### PR TITLE
V2 theme cleanup

### DIFF
--- a/autoload/lightline/colorscheme/embark.vim
+++ b/autoload/lightline/colorscheme/embark.vim
@@ -1,5 +1,4 @@
 " Colors
-" challenger deep colors:
 let s:deep_space= { "gui": "#100E23", "cterm": "232", "cterm16": "8"}
 let s:space = { "gui": "#1e1c31", "cterm": "233", "cterm16": "NONE"}
 let s:eclipse = { "gui": "#3E3859", "cterm": "236", "cterm16": "0"}
@@ -32,7 +31,7 @@ let s:norm            = s:clouds
 let s:norm_subtle     = s:dark_clouds
 let s:visual          = s:bg_bright
 
-" lightline challenger deep colors:
+" lightline embark colors
 let s:lfc = {
       \'space': [s:space.gui, s:space.cterm16],
       \'deep_space': [s:deep_space.gui, s:deep_space.cterm16],

--- a/autoload/lightline/colorscheme/embark.vim
+++ b/autoload/lightline/colorscheme/embark.vim
@@ -22,7 +22,7 @@ let s:cyan = { "gui": "#aaffe4", "cterm": "122", "cterm16": "6"}
 let s:dark_cyan = { "gui": "#63f2f1", "cterm": "121", "cterm16": "14"}
 
 let s:clouds = { "gui": "#cbe3e7", "cterm": "253", "cterm16": "7"}
-let s:dark_clouds = { "gui": "#a6b3cc", "cterm": "252", "cterm16": "15"}
+let s:dark_clouds = { "gui": "#6B697E", "cterm": "252", "cterm16": "15"}
 
 let s:bg              = s:space
 let s:bg_dark       = s:deep_space
@@ -66,9 +66,9 @@ let s:p.tabline.middle  = [ [ s:lfc.clouds, s:lfc.bg_dark ] ]
 let s:p.tabline.right   = [ [ s:lfc.bg_dark, s:lfc.dark_cyan ] ]
 
 " Normal mode
-let s:p.normal.left     = [ [ s:lfc.bg_dark, s:lfc.cyan ],  [ s:lfc.dark_clouds, s:lfc.eclipse ] ]
+let s:p.normal.left     = [ [ s:lfc.bg_dark, s:lfc.cyan ],  [ s:lfc.clouds, s:lfc.eclipse ] ]
 let s:p.normal.middle   = [ [ s:lfc.clouds, s:lfc.bg_dark ] ]
-let s:p.normal.right    = [ [ s:lfc.bg_dark, s:lfc.cyan ],  [ s:lfc.dark_clouds, s:lfc.eclipse ] ]
+let s:p.normal.right    = [ [ s:lfc.bg_dark, s:lfc.cyan ],  [ s:lfc.clouds, s:lfc.eclipse ] ]
 let s:p.normal.error    = [ [ s:lfc.red, s:lfc.bg_dark ] ]
 let s:p.normal.warning  = [ [ s:lfc.yellow, s:lfc.bg_dark ] ]
 

--- a/colors/embark.vim
+++ b/colors/embark.vim
@@ -25,13 +25,19 @@ endif
 " == COLOR PALETTE == 
 "
 " TODO: Cterm values here are OG from Challenger Deep
-let s:deep_space= { "gui": "#100E23", "cterm": "232", "cterm16": "0"}
-let s:space = { "gui": "#1e1c31", "cterm": "233", "cterm16": "NONE"}
-let s:eclipse = { "gui": "#585273", "cterm": "236", "cterm16": "8"}
 
-let s:stardust = { "gui": "#cbe3e7", "cterm": "253", "cterm16": "7"}
-let s:cosmos = { "gui": "#a6b3cc", "cterm": "252", "cterm16": "15"}
+" Space
+let s:space0 = { "gui": "#100E23", "cterm": "232", "cterm16": "0"}
+let s:space1 = { "gui": "#1e1c31", "cterm": "233", "cterm16": "NONE"}
+let s:space2 = { "gui": "#2D2B40", "cterm": "233", "cterm16": "NONE" }
+let s:space3 = { "gui": "#3E3859", "cterm": "236", "cterm16": "8"}
+let s:space4 = { "gui": "#585273", "cterm": "236", "cterm16": "8"}
 
+" Astral
+let s:astral0 = {"gui": "#8A889D", "cterm": "252", "cterm16": "15"}
+let s:astral1 = { "gui": "#cbe3e7", "cterm": "253", "cterm16": "7"}
+
+" Nebula
 let s:red = { "gui": "#F48FB1", "cterm": "204", "cterm16": "1"}
 let s:dark_red = { "gui": "#F02E6E", "cterm": "203", "cterm16": "9"}
 
@@ -50,14 +56,12 @@ let s:dark_purple = { "gui": "#a37acc", "cterm": "135", "cterm16": "13"}
 let s:cyan = { "gui": "#87DFEB", "cterm": "122", "cterm16": "6"}
 let s:dark_cyan = { "gui": "#63f2f1", "cterm": "121", "cterm16": "14"}
 
-let s:medium_gray     = { "gui": "#767676", "cterm": "243", "cterm16" : "243" }
-
-let s:bg              = s:space
-let s:bg_dark       = s:deep_space
-let s:bg_bright         = s:eclipse
-let s:norm            = s:stardust
-let s:norm_subtle     = s:cosmos
-let s:visual          = s:bg_bright
+let s:bg              = s:space1
+let s:bg_dark       = s:space0
+let s:bg_bright         = s:space4
+let s:norm            = s:astral1
+let s:norm_subtle     = s:astral0
+let s:visual          = s:space3
 
 let s:head_a         = s:dark_blue
 let s:head_b         = s:blue
@@ -93,7 +97,7 @@ endfunction
 " (see `:h w18`)
 call s:h("Normal",        {"bg": s:bg, "fg": s:norm})
 call s:h("Cursor",        {"bg": s:blue, "fg": s:bg_bright})
-call s:h("Comment",       {"fg": s:medium_gray, "gui": "italic", "cterm": "italic"})
+call s:h("Comment",       {"fg": s:norm_subtle, "gui": "italic", "cterm": "italic"})
 
 call s:h("Constant",      {"fg": s:yellow})
 hi! link String           Constant
@@ -149,19 +153,19 @@ call s:h("Float",    {"fg": s:dark_yellow})
 call s:h("NonText",       {"fg": s:bg_bright})
 call s:h("Directory",     {"fg": s:purple})
 call s:h("ErrorMsg",      {"fg": s:dark_red})
-call s:h("IncSearch",     {"bg": s:yellow, "fg": s:space})
-call s:h("Search",        {"bg": s:dark_yellow, "fg": s:space})
-call s:h("MoreMsg",       {"fg": s:medium_gray, "gui": "bold", "cterm": "bold"})
+call s:h("IncSearch",     {"bg": s:yellow, "fg": s:bg})
+call s:h("Search",        {"bg": s:dark_yellow, "fg": s:bg})
+call s:h("MoreMsg",       {"fg": s:norm_subtle, "gui": "bold", "cterm": "bold"})
 hi! link ModeMsg MoreMsg
 
-call s:h("LineNr",        {"fg": s:eclipse, "bg": s:bg_dark})
+call s:h("LineNr",        {"fg": s:space4, "bg": s:bg_dark})
 hi LineNr guibg=NONE ctermbg=NONE
 
 call s:h("CursorLineNr",  {"bg": s:bg_dark, "fg": s:blue, "gui": "bold"})
 call s:h("Question",      {"fg": s:red})
 call s:h("StatusLine",    {"bg": s:bg_bright})
 call s:h("Conceal",       {"fg": s:norm})
-call s:h("StatusLineNC",  {"bg": s:bg_bright, "fg": s:medium_gray})
+call s:h("StatusLineNC",  {"bg": s:bg_bright, "fg": s:norm_subtle})
 call s:h("VertSplit",     {"fg": s:bg_dark})
 call s:h("Title",         {"fg": s:dark_blue})
 call s:h("Visual",        {"bg": s:visual})
@@ -169,10 +173,10 @@ call s:h("WarningMsg",    {"fg": s:yellow})
 call s:h("WildMenu",      {"fg": s:bg_dark, "bg": s:cyan})
 call s:h("Folded",        {"fg": s:dark_purple})
 call s:h("FoldColumn",    {"fg": s:yellow})
-call s:h("DiffAdd",       {"fg": s:space, "bg": s:dark_green})
-call s:h("DiffDelete",    {"fg": s:space, "bg": s:red})
-call s:h("DiffChange",    {"fg": s:space, "bg": s:dark_yellow})
-call s:h("DiffText",      {"fg": s:space, "bg": s:dark_yellow, "gui": "bold"})
+call s:h("DiffAdd",       {"fg": s:bg, "bg": s:dark_green})
+call s:h("DiffDelete",    {"fg": s:bg, "bg": s:red})
+call s:h("DiffChange",    {"fg": s:bg, "bg": s:dark_yellow})
+call s:h("DiffText",      {"fg": s:bg, "bg": s:dark_yellow, "gui": "bold"})
 call s:h("SignColumn",    {"fg": s:green})
 
 if has("gui_running")
@@ -186,8 +190,8 @@ else
   call s:h("SpellRare",   {"cterm": "underline", "fg": s:red})
   call s:h("SpellLocal",  {"cterm": "underline", "fg": s:dark_green})
 endif
-call s:h("Pmenu",         {"fg": s:norm, "bg": s:deep_space})
-call s:h("PmenuSel",      {"fg": s:purple, "bg": s:space})
+call s:h("Pmenu",         {"fg": s:norm, "bg": s:space2})
+call s:h("PmenuSel",      {"fg": s:purple, "bg": s:bg})
 call s:h("PmenuSbar",     {"fg": s:norm, "bg": s:bg_dark})
 call s:h("PmenuThumb",    {"fg": s:norm, "bg": s:bg_dark})
 call s:h("TabLine",       {"fg": s:norm, "bg": s:bg_bright})
@@ -237,33 +241,33 @@ call s:h("mckarkdownH5",                  {"fg": s:head_a})
 call s:h("markdownH6",                  {"fg": s:head_a})
 call s:h("markdownHeadingDelimiter",    {"fg": s:norm})
 call s:h("markdownHeadingRule",         {"fg": s:norm})
-call s:h("markdownId",                  {"fg": s:medium_gray})
+call s:h("markdownId",                  {"fg": s:norm_subtle})
 call s:h("markdownIdDeclaration",       {"fg": s:norm_subtle})
 call s:h("markdownItalic",              {"fg": s:norm  , "gui": "italic"     , "cterm": "italic"})
-call s:h("markdownLinkDelimiter",       {"fg": s:medium_gray})
+call s:h("markdownLinkDelimiter",       {"fg": s:norm_subtle})
 call s:h("markdownLinkText",            {"fg": s:norm})
-call s:h("markdownLinkTextDelimiter",   {"fg": s:medium_gray})
+call s:h("markdownLinkTextDelimiter",   {"fg": s:norm_subtle})
 call s:h("markdownListMarker",          {"fg": s:norm})
 call s:h("markdownOrderedListMarker",   {"fg": s:norm})
 call s:h("markdownRule",                {"fg": s:norm})
-call s:h("markdownUrl",                 {"fg": s:medium_gray, "gui": "underline", "cterm": "underline"})
-call s:h("markdownUrlDelimiter",        {"fg": s:medium_gray})
+call s:h("markdownUrl",                 {"fg": s:norm_subtle, "gui": "underline", "cterm": "underline"})
+call s:h("markdownUrlDelimiter",        {"fg": s:norm_subtle})
 call s:h("markdownUrlTitle",            {"fg": s:norm})
-call s:h("markdownUrlTitleDelimiter",   {"fg": s:medium_gray})
+call s:h("markdownUrlTitleDelimiter",   {"fg": s:norm_subtle})
 call s:h("markdownCode",                {"fg": s:norm})
 call s:h("markdownCodeDelimiter",       {"fg": s:norm})
 
 " plasticboy/vim-markdown
 call s:h("mkdBlockQuote",               {"fg": s:norm})
-call s:h("mkdDelimiter",                {"fg": s:medium_gray})
-call s:h("mkdID",                       {"fg": s:medium_gray})
+call s:h("mkdDelimiter",                {"fg": s:norm_subtle})
+call s:h("mkdID",                       {"fg": s:norm_subtle})
 call s:h("mkdLineContinue",             {"fg": s:norm})
 call s:h("mkdLink",                     {"fg": s:norm})
-call s:h("mkdLinkDef",                  {"fg": s:medium_gray})
+call s:h("mkdLinkDef",                  {"fg": s:norm_subtle})
 call s:h("mkdListItem",                 {"fg": s:norm})
 call s:h("mkdNonListItemBlock",         {"fg": s:norm})  " bug in syntax?
 call s:h("mkdRule",                     {"fg": s:norm})
-call s:h("mkdUrl",                      {"fg": s:medium_gray, "gui": "underline", "cterm": "underline"})
+call s:h("mkdUrl",                      {"fg": s:norm_subtle, "gui": "underline", "cterm": "underline"})
 call s:h("mkdCode",                     {"fg": s:norm})
 call s:h("mkdIndentCode",               {"fg": s:norm})
 
@@ -271,16 +275,16 @@ call s:h("mkdIndentCode",               {"fg": s:norm})
 call s:h("markdownBlockquoteDelimiter", {"fg": s:norm})
 call s:h("markdownInlineDelimiter",     {"fg": s:norm})
 call s:h("markdownItemDelimiter",       {"fg": s:norm})
-call s:h("markdownLinkReference",       {"fg": s:medium_gray})
+call s:h("markdownLinkReference",       {"fg": s:norm_subtle})
 call s:h("markdownLinkText",            {"fg": s:norm})
-call s:h("markdownLinkTextContainer",   {"fg": s:medium_gray})
-call s:h("markdownLinkUrl",             {"fg": s:medium_gray, "gui": "underline", "cterm": "underline"})
-call s:h("markdownLinkUrlContainer",    {"fg": s:medium_gray})
+call s:h("markdownLinkTextContainer",   {"fg": s:norm_subtle})
+call s:h("markdownLinkUrl",             {"fg": s:norm_subtle, "gui": "underline", "cterm": "underline"})
+call s:h("markdownLinkUrlContainer",    {"fg": s:norm_subtle})
 call s:h("markdownFencedCodeBlock",     {"fg": s:norm})
 call s:h("markdownInlineCode",          {"fg": s:norm})
 
 " mattly/vim-markdown-enhancements
-call s:h("mmdFootnoteDelimiter",        {"fg": s:medium_gray})
+call s:h("mmdFootnoteDelimiter",        {"fg": s:norm_subtle})
 call s:h("mmdFootnoteMarker",           {"fg": s:norm})
 call s:h("mmdTableAlign",               {"fg": s:norm})
 call s:h("mmdTableDelimiter",           {"fg": s:norm})
@@ -295,7 +299,7 @@ hi! link xmlEndTag                  xmlTag
 hi! link xmlTagName                 htmlTagName
 
 call s:h("MatchParen",    {"bg": s:bg_dark, "fg": s:purple, "gui": "bold", "cterm": "bold"})
-call s:h("qfLineNr",      {"fg": s:medium_gray})
+call s:h("qfLineNr",      {"fg": s:norm_subtle})
 
 " Signify, git-gutter
 hi link SignifySignAdd              LineNr
@@ -333,7 +337,7 @@ let g:terminal_color_3 = s:yellow.gui
 let g:terminal_color_4 = s:blue.gui
 let g:terminal_color_5 = s:purple.gui
 let g:terminal_color_6 = s:cyan.gui
-let g:terminal_color_7 = s:space.gui
+let g:terminal_color_7 = s:bg.gui
 let g:terminal_color_8 = s:bg_dark.gui
 let g:terminal_color_9 = s:dark_red.gui
 let g:terminal_color_10 = s:dark_green.gui
@@ -341,5 +345,5 @@ let g:terminal_color_11 = s:dark_yellow.gui
 let g:terminal_color_12 = s:dark_blue.gui
 let g:terminal_color_13 = s:dark_purple.gui
 let g:terminal_color_14 = s:dark_cyan.gui
-let g:terminal_color_15 = s:cosmos.gui
+let g:terminal_color_15 = s:norm_subtle.gui
 


### PR DESCRIPTION
This commit is a large overhaul of things that have always bothered me
about the theme. Overall this update gives the theme more unity and the
right level of contrast that I have always wanted.

* New color code #2D2B40

This color works wonderful for pop up messages and has become the new
Pmenu color. The gap between the dark purples and lighter grays was very
large and this color becomes a subtle color to put in the middle of
them.

* Bring back #3E3859

This was the old linenr and visual highlight color. It never worked well
as the linenr because it had poor contrast, but it was a much better
visual highlight color than #585273. There is no reason to not have both
in the project at the same time.

* Update dark white color to #6B697E

The old white color of #A6B3CC was not being used in a core way of the
theme. One of my biggest gripes was that the color of comments was very
gray without having unity with the theme. There was an opportunity to
make this color work better for comments and give it its due in the
project.

* Rename color codes

The color codes before had unique names which made it frustrating to
reference them. I don't want to get rid of the spirit that having these
names bring to the theme thrown away though. Instead each "group" of
colors will have its own name and number designation. This is very
similar to Nord themes take (a huge influence of this theme).