### PR TITLE
fix(nvim-lsp): updated highlight group names

### DIFF
--- a/colors/embark.vim
+++ b/colors/embark.vim
@@ -337,7 +337,7 @@ call s:h("CtrlpMatch", {"fg": s:yellow})
 call s:h("NERDTreeDir", {"fg": s:blue})
 call s:h("NERDTreeFlags", {"fg": s:green})
 
-" nvim LSP
+" nvim LSP (legacy, kept here for retro-compatibility)
 call s:h ("LspDiagnosticsError", {"fg": s:red, "bg": s:bg_dark})
 call s:h ("LspDiagnosticsWarning", {"fg": s:yellow, "bg": s:bg_dark})
 call s:h ("LspDiagnosticsInformation", {"fg": s:blue, "bg": s:bg_dark})
@@ -346,6 +346,21 @@ call s:h ("LspDiagnosticsErrorSign", {"bg": s:bg})
 call s:h ("LspDiagnosticsWarningSign", {"bg": s:bg})
 call s:h ("LspDiagnosticsInformationSign", {"bg": s:bg})
 call s:h ("LspDiagnosticsHintSign", {"bg": s:bg})
+
+" nvim LSP (updated version for neovim master 35325ddac)
+call s:h ("LspDiagnosticsDefaultError", {"fg": s:red, "bg": s:bg_dark})
+call s:h ("LspDiagnosticsDefaultWarning", {"fg": s:yellow, "bg": s:bg_dark})
+call s:h ("LspDiagnosticsDefaultInformation", {"fg": s:blue, "bg": s:bg_dark})
+call s:h ("LspDiagnosticsDefaultHint", {"fg": s:purple, "bg": s:bg_dark})
+call s:h ("LspDiagnosticsSignError", {"bg": s:bg})
+call s:h ("LspDiagnosticsSignWarning", {"bg": s:bg})
+call s:h ("LspDiagnosticsSignInformation", {"bg": s:bg})
+call s:h ("LspDiagnosticsSignHint", {"bg": s:bg})
+call s:h ("LspDiagnosticsUnderlineError", {"cterm": "undercurl", "gui": "undercurl"})
+call s:h ("LspDiagnosticsFloatingError", {"bg": s:space2, "fg": s:red})
+call s:h ("LspDiagnosticsFloatingWarning", {"bg": s:space2, "fg": s:yellow})
+call s:h ("LspDiagnosticsFloatingInformation", {"bg": s:space2, "fg": s:blue})
+call s:h ("LspDiagnosticsFloatingHint", {"bg": s:space2, "fg": s:purple})
 
 " nvim terminal colors
 let g:terminal_color_0 = s:bg_bright.gui


### PR DESCRIPTION
👋 

[diagnostic-nvim](https://github.com/nvim-lua/diagnostic-nvim/) got more or less merged with neovim master; and with that the highlight group names have been changed for consistency with the rest of the LSP related stuff.

I chose to leave the previous groups in there so that it won't mess up the install for people not running bleeding edge neovim:master.

See https://github.com/nvim-lua/diagnostic-nvim/issues/73 for more info.

<img width="964" alt="Screenshot 2020-11-13 at 18 18 13" src="https://user-images.githubusercontent.com/145502/99101336-61db7980-25d4-11eb-868a-6b6893c76e0a.png">
